### PR TITLE
Configured calls in Module

### DIFF
--- a/src/Guardrail.sol
+++ b/src/Guardrail.sol
@@ -237,6 +237,10 @@ contract Guardrail is ITransactionGuard, IModuleGuard {
         override
         returns (bytes32)
     {
+        if (_checkAllowedDelegate(msg.sender, to)) {
+            return;
+        }
+
         _delegateCallNotAllowed(operation);
         return bytes32(0);
     }

--- a/src/Guardrail.sol
+++ b/src/Guardrail.sol
@@ -231,14 +231,13 @@ contract Guardrail is ITransactionGuard, IModuleGuard {
     /**
      * @inheritdoc IModuleGuard
      */
-    function checkModuleTransaction(address, uint256, bytes calldata, Enum.Operation operation, address)
+    function checkModuleTransaction(address to, uint256, bytes calldata, Enum.Operation operation, address)
         external
-        pure
         override
         returns (bytes32)
     {
         if (_checkAllowedDelegate(msg.sender, to)) {
-            return;
+            return bytes32(0);
         }
 
         _delegateCallNotAllowed(operation);


### PR DESCRIPTION
Fixes #3 

## TLDR
- Allow particular delegate calls from the module

## LLM Description
This pull request introduces a change to the `Guardrail` contract to add a delegate call check for allowed delegates before proceeding with the `_delegateCallNotAllowed` logic.

### Key Change:

* **Delegate Call Check Added**:
  - In the `Guardrail` contract (`src/Guardrail.sol`), a new condition was added to check if the delegate call is allowed for the sender and target (`_checkAllowedDelegate(msg.sender, to)`). If the call is allowed, the function returns early without executing the `_delegateCallNotAllowed` logic.