### PR TITLE
Optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ docs/
 
 # Foundry gas snapshot
 .gas-snapshot
+
+# VS Code
+.vscode/

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,5 +3,6 @@ src = "src"
 out = "out"
 libs = ["lib"]
 via_ir = true
+optimizer = true
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,5 +4,6 @@ out = "out"
 libs = ["lib"]
 via_ir = true
 optimizer = true
+optimizer-runs = 10_000_000
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/src/Guardrail.sol
+++ b/src/Guardrail.sol
@@ -148,7 +148,11 @@ contract Guardrail is ITransactionGuard, IModuleGuard {
      * @dev This will fail if the delegate allowance is not scheduled
      */
     function delegateAllowance(address safe, address to, bool oneTimeAllowance, bool reset) public {
-        _delegateAllowance(safe, to, oneTimeAllowance, reset ? 0 : DELAY + block.timestamp);
+        if (reset) {
+            delete delegatedAllowance[safe][to];
+        } else {
+            _delegateAllowance(safe, to, oneTimeAllowance, DELAY + block.timestamp);
+        }
     }
 
     /**

--- a/src/Guardrail.sol
+++ b/src/Guardrail.sol
@@ -4,29 +4,26 @@ pragma solidity =0.8.28;
 import {ITransactionGuard, IERC165, GuardManager} from "safe-smart-account/contracts/base/GuardManager.sol";
 import {IModuleGuard} from "safe-smart-account/contracts/base/ModuleManager.sol";
 import {Enum} from "safe-smart-account/contracts/libraries/Enum.sol";
+import {SafeInterface} from "./interfaces/SafeInterface.sol";
 
 contract Guardrail is ITransactionGuard, IModuleGuard {
     /**
      * @notice The allowance struct to store the status of the delegate
-     * @param allowed The status of the delegate
      * @param oneTimeAllowance The status of the one time allowance
+     * @param allowedTimestamp The timestamp from when the delegate is allowed
      * @dev The one time allowance is used to allow the delegate to execute a transaction only once
      */
     struct Allowance {
-        bool allowed;
         bool oneTimeAllowance;
+        uint248 allowedTimestamp;
     }
 
     /**
-     * @notice The allowance schedule struct to store the timestamp and one time allowance status
-     * @param timestamp The timestamp of the schedule
-     * @param oneTimeAllowance The status of the one time allowance
-     * @dev The one time allowance is used to allow the delegate to execute a transaction only once
+     * @notice The storage slot for the guard
+     * @dev This is used to check if the guard is set
+     *      Value = `keccak256("guard_manager.guard.address")`
      */
-    struct AllowanceSchedule {
-        uint256 timestamp;
-        bool oneTimeAllowance;
-    }
+    bytes32 public constant GUARD_STORAGE_SLOT = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
 
     /**
      * @notice The delay for the guard removal and delegate allowance
@@ -49,14 +46,6 @@ contract Guardrail is ITransactionGuard, IModuleGuard {
     mapping(address safe => mapping(address to => Allowance allowance)) public delegatedAllowance;
 
     /**
-     * @notice The schedule for the delegated allowance update
-     * @dev safe The address of the safe
-     *      to The address of the delegate
-     *      allowanceSchedule The schedule for the delegated allowance
-     */
-    mapping(address safe => mapping(address to => AllowanceSchedule allowanceSchedule)) public delegatedUpdateSchedule;
-
-    /**
      * @notice Event emitted when the guard removal is scheduled
      * @param safe The address of the safe
      * @param timestamp The timestamp of the schedule
@@ -64,21 +53,13 @@ contract Guardrail is ITransactionGuard, IModuleGuard {
     event GuardRemovalScheduled(address indexed safe, uint256 timestamp);
 
     /**
-     * @notice Event emitted when the delegate allowance is scheduled
-     * @param safe The address of the safe
-     * @param to The address of the delegate
-     * @param timestamp The timestamp of the schedule
-     */
-    event DelegateAllowanceScheduled(address indexed safe, address indexed to, uint256 timestamp);
-
-    /**
      * @notice Event emitted when the delegate allowance is updated
      * @param safe The address of the safe
      * @param to The address of the delegate
-     * @param newAllowance The status of the new allowance
      * @param oneTimeAllowance The status of the one time allowance
+     * @param timestamp The timestamp at which the delegate is allowed
      */
-    event DelegateAllowanceUpdated(address indexed safe, address indexed to, bool newAllowance, bool oneTimeAllowance);
+    event DelegateAllowanceUpdated(address indexed safe, address indexed to, bool oneTimeAllowance, uint256 timestamp);
 
     /**
      * @notice Error indicating invalid timestamp
@@ -87,9 +68,15 @@ contract Guardrail is ITransactionGuard, IModuleGuard {
     error InvalidTimestamp();
 
     /**
-     * @notice Error indicating that the operation DelegateCall is not allowed
+     * @notice Error indicating that the guard is already set
      */
-    error DelegateCallNotAllowed();
+    error GuardAlreadySet();
+
+    /**
+     * @notice Error indicating that the operation DelegateCall is not allowed
+     * @param to The address of the delegate to which the operation is not allowed
+     */
+    error DelegateCallNotAllowed(address to);
 
     /**
      * @notice Error indicating that the selector is invalid
@@ -124,32 +111,44 @@ contract Guardrail is ITransactionGuard, IModuleGuard {
     }
 
     /**
-     * @notice Function to schedule the delegate allowance
+     * @notice Function to set the delegate allowance immediately
      * @param to The address of the delegate
      * @param oneTime The status of the one time allowance
-     * @dev The one time allowance is used to allow the delegate to execute a transaction only once
+     * @dev This can be used to set the delegate allowance immediately if the guard is not set
      */
-    function scheduleDelegateAllowance(address to, bool oneTime) public {
-        delegatedUpdateSchedule[msg.sender][to] = AllowanceSchedule(DELAY + block.timestamp, oneTime);
+    function immediateDelegateAllowance(address to, bool oneTime) public {
+        require(
+            abi.decode(SafeInterface(msg.sender).getStorageAt(uint256(GUARD_STORAGE_SLOT), 1), (address)) == address(0),
+            GuardAlreadySet()
+        );
 
-        emit DelegateAllowanceScheduled(msg.sender, to, DELAY + block.timestamp);
+        _delegateAllowance(msg.sender, to, oneTime, block.timestamp);
+    }
+
+    /**
+     * @notice Internal function to set the delegate allowance
+     * @param safe The address of the safe
+     * @param to The address of the delegate
+     * @param timestamp The timestamp at which the delegate is allowed
+     * @param oneTimeAllowance The status of the one time allowance
+     * @dev This will emit the DelegateAllowanceUpdated event
+     */
+    function _delegateAllowance(address safe, address to, bool oneTimeAllowance, uint256 timestamp) internal {
+        delegatedAllowance[safe][to] = Allowance(oneTimeAllowance, uint248(timestamp));
+
+        emit DelegateAllowanceUpdated(safe, to, oneTimeAllowance, timestamp);
     }
 
     /**
      * @notice Function to update the delegate allowance
      * @param safe The address of the safe
      * @param to The address of the delegate
+     * @param oneTimeAllowance The status of the one time allowance
+     * @param reset true if the delegate allowance should be reset
      * @dev This will fail if the delegate allowance is not scheduled
      */
-    function delegateAllowance(address safe, address to) public {
-        AllowanceSchedule memory allowanceSchedule = delegatedUpdateSchedule[safe][to];
-        require(allowanceSchedule.timestamp > 0 && allowanceSchedule.timestamp < block.timestamp, InvalidTimestamp());
-
-        bool oldAllowance = delegatedAllowance[safe][to].allowed;
-        delegatedAllowance[safe][to] = Allowance(!oldAllowance, allowanceSchedule.oneTimeAllowance);
-        delete delegatedUpdateSchedule[safe][to];
-
-        emit DelegateAllowanceUpdated(safe, to, !oldAllowance, allowanceSchedule.oneTimeAllowance);
+    function delegateAllowance(address safe, address to, bool oneTimeAllowance, bool reset) public {
+        _delegateAllowance(safe, to, oneTimeAllowance, reset ? 0 : DELAY + block.timestamp);
     }
 
     /**
@@ -168,30 +167,25 @@ contract Guardrail is ITransactionGuard, IModuleGuard {
     }
 
     /**
-     * @notice Function to check if the delegate is allowed
+     * @notice Function to check if the delegate is allowed if the operation is delegate call
      * @param safe The address of the safe
      * @param to The address of the delegate
-     * @return allowed The status of the delegate
-     * @dev This will return true if the delegate is allowed and false if the delegate is not allowed. This will also
+     * @param operation The operation to check
+     * @dev This will revert if the operation is delegate call, but the {to} is not a allowed delegate. This will also
      *      remove the delegate allowance if the one time allowance is set
      */
-    function _checkAllowedDelegate(address safe, address to) internal returns (bool allowed) {
-        Allowance memory allowance = delegatedAllowance[safe][to];
-        if (allowance.allowed) {
+    function _checkOperationAndAllowance(address safe, address to, Enum.Operation operation) internal {
+        if (operation == Enum.Operation.DelegateCall) {
+            Allowance memory allowance = delegatedAllowance[safe][to];
+            require(
+                allowance.allowedTimestamp > 0 && allowance.allowedTimestamp < block.timestamp,
+                DelegateCallNotAllowed(to)
+            );
+
             if (allowance.oneTimeAllowance) {
                 delete delegatedAllowance[safe][to];
             }
-            allowed = true;
         }
-    }
-
-    /**
-     * @notice Internal function to check if the operation is DelegateCall
-     * @param operation The operation to check
-     * @dev This will revert if the operation is DelegateCall
-     */
-    function _delegateCallNotAllowed(Enum.Operation operation) internal pure {
-        require(operation != Enum.Operation.DelegateCall, DelegateCallNotAllowed());
     }
 
     /**
@@ -216,11 +210,7 @@ contract Guardrail is ITransactionGuard, IModuleGuard {
             _removeGuard(msg.sender);
         }
 
-        if (_checkAllowedDelegate(msg.sender, to)) {
-            return;
-        }
-
-        _delegateCallNotAllowed(operation);
+        _checkOperationAndAllowance(msg.sender, to, operation);
     }
 
     /**
@@ -236,11 +226,8 @@ contract Guardrail is ITransactionGuard, IModuleGuard {
         override
         returns (bytes32)
     {
-        if (_checkAllowedDelegate(msg.sender, to)) {
-            return bytes32(0);
-        }
+        _checkOperationAndAllowance(msg.sender, to, operation);
 
-        _delegateCallNotAllowed(operation);
         return bytes32(0);
     }
 

--- a/src/interfaces/SafeInterface.sol
+++ b/src/interfaces/SafeInterface.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity =0.8.28;
+
+import {ISafe} from "safe-smart-account/contracts/interfaces/ISafe.sol";
+
+/**
+ * @title SafeInterface
+ * @dev This interface is used to interact with the Safe contract.
+ *      It extends the ISafe interface to include a function for reading storage.
+ */
+interface SafeInterface is ISafe {
+    /**
+     * @notice Reads `length` bytes of storage in the current contract
+     * @param offset - the offset in the current contract's storage in words to start reading from
+     * @param length - the number of words (32 bytes) of data to read
+     * @return the bytes that were read.
+     */
+    function getStorageAt(uint256 offset, uint256 length) external view returns (bytes memory);
+}


### PR DESCRIPTION
Fixes #4 

# TLDR
### Implemented the following:
- [x] We should have a single mapping:
    ```solidity
    struct Allowance {
        bool oneTimeAllowance;
        uint248 timestamp;
    }
    ```
    This would allow us to have a single `delegateAllowance()` transaction that sets the timestamp, and then the allowance check becomes `allowance.timestamp != 0 && allowance.timestamp < now()`.
- [x] Removing delegated allowances should not require a delay.

### Didn't implement the below:
> We can make the `MultiSendCallOnly` contract allowed without reading storage. It accounts for 99% of all `DELEGATECALL`s and would be a small optimization win.

Reasoning: Even if 99% of the `DELEGATECALL`'s are through `MultiSendCallOnly`, I don't think we should enable it for 100% of the users of the guard, as they may not enable it or require it by default. As this is a security-focused initiative, I think we can skip this one to be a bit more cautious. 

# LLM Description
This pull request introduces significant changes to the `Guardrail` contract, improving its functionality and security, alongside configuration updates and the addition of a new interface. The most important changes include replacing the delegate allowance scheduling mechanism, introducing a new storage slot for guards, and refactoring functions for better clarity and modularity.

### Changes to `Guardrail` Contract:

* **Delegate Allowance Mechanism Overhaul:**
  - Replaced the `scheduleDelegateAllowance` function with `immediateDelegateAllowance` for setting delegate allowances immediately if no guard is set. Removed the `delegatedUpdateSchedule` mapping and associated events. (`src/Guardrail.sol`, [src/Guardrail.solL127-R151](diffhunk://#diff-14721534964810da5a04ceab21acfdd984a2fbb0e37828ce58d231a49906384aL127-R151))
  - Updated the `delegateAllowance` function to include a `reset` parameter and refactored the logic into a new `_delegateAllowance` internal function. (`src/Guardrail.sol`, [src/Guardrail.solL127-R151](diffhunk://#diff-14721534964810da5a04ceab21acfdd984a2fbb0e37828ce58d231a49906384aL127-R151))

* **Guard Storage Slot Introduction:**
  - Added a new constant `GUARD_STORAGE_SLOT` to store the guard's address securely in the contract's storage. (`src/Guardrail.sol`, [src/Guardrail.solR7-R26](diffhunk://#diff-14721534964810da5a04ceab21acfdd984a2fbb0e37828ce58d231a49906384aR7-R26))

* **Refactored Delegate Call Checks:**
  - Consolidated delegate call checks into `_checkOperationAndAllowance`, which validates operations and ensures the delegate's allowance is correctly handled. Removed redundant functions like `_checkAllowedDelegate` and `_delegateCallNotAllowed`. (`src/Guardrail.sol`, [[1]](diffhunk://#diff-14721534964810da5a04ceab21acfdd984a2fbb0e37828ce58d231a49906384aL171-L194) [[2]](diffhunk://#diff-14721534964810da5a04ceab21acfdd984a2fbb0e37828ce58d231a49906384aL219-R213) [[3]](diffhunk://#diff-14721534964810da5a04ceab21acfdd984a2fbb0e37828ce58d231a49906384aL239-L243)

* **Event and Struct Changes:**
  - Updated the `DelegateAllowanceUpdated` event to include a timestamp instead of a boolean allowance status. Removed the `AllowanceSchedule` struct and its associated event. (`src/Guardrail.sol`, [src/Guardrail.solL51-R79](diffhunk://#diff-14721534964810da5a04ceab21acfdd984a2fbb0e37828ce58d231a49906384aL51-R79))

### Other Updates:

* **New Interface Addition:**
  - Added `SafeInterface` to extend the `ISafe` interface, enabling reading contract storage via the `getStorageAt` function. (`src/interfaces/SafeInterface.sol`, [src/interfaces/SafeInterface.solR1-R19](diffhunk://#diff-64d77b70a504bd1af0ffdcc340fd1675f0454d7070698cf03df62bd382682cb2R1-R19))

* **Configuration Updates:**
  - Enabled the optimizer in `foundry.toml` for better contract performance. (`foundry.toml`, [foundry.tomlR6](diffhunk://#diff-bac743fe3d899998e32393af53af8cc7d28c89c3d7fabfa48b01361cf8d42d9bR6))
  - Updated the `forge-std` submodule to a newer commit. (`lib/forge-std`, [lib/forge-stdL1-R1](diffhunk://#diff-6051beac93db46f91e15cb961b50d2a55e6ecad9605b4ff7f4063901486e91e6L1-R1))