### PR TITLE
OZ Install and using `msg.sender`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = lib/safe-smart-account
 	url = https://github.com/safe-global/safe-smart-account
 	branch = main
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/src/Guardrail.sol
+++ b/src/Guardrail.sol
@@ -141,17 +141,16 @@ contract Guardrail is ITransactionGuard, IModuleGuard {
 
     /**
      * @notice Function to update the delegate allowance
-     * @param safe The address of the safe
      * @param to The address of the delegate
      * @param oneTimeAllowance The status of the one time allowance
      * @param reset true if the delegate allowance should be reset
      * @dev This will fail if the delegate allowance is not scheduled
      */
-    function delegateAllowance(address safe, address to, bool oneTimeAllowance, bool reset) public {
+    function delegateAllowance(address to, bool oneTimeAllowance, bool reset) public {
         if (reset) {
-            delete delegatedAllowance[safe][to];
+            delete delegatedAllowance[msg.sender][to];
         } else {
-            _delegateAllowance(safe, to, oneTimeAllowance, DELAY + block.timestamp);
+            _delegateAllowance(msg.sender, to, oneTimeAllowance, DELAY + block.timestamp);
         }
     }
 


### PR DESCRIPTION
# TLDR
- Using `msg.sender` in `delegateAllowance(...)`

# LLM Description
This pull request introduces a new submodule for OpenZeppelin contracts, updates the `delegateAllowance` function in the `Guardrail` contract to improve security by using `msg.sender` instead of an externally passed `safe` address, and adjusts related logic accordingly.

### Submodule Addition:
* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R8-R10): Added a new submodule for OpenZeppelin contracts, located at `lib/openzeppelin-contracts`. This submodule will allow the project to utilize OpenZeppelin's libraries.
* [`lib/openzeppelin-contracts`](diffhunk://#diff-1bd82b383e04dbbbbbd4f7d8ab4e76506f9b5fa6ca80d34f279fdd32cf740a8eR1): Added a submodule commit reference pointing to a specific commit in the OpenZeppelin repository.

### Contract Security Improvement:
* [`src/Guardrail.sol`](diffhunk://#diff-14721534964810da5a04ceab21acfdd984a2fbb0e37828ce58d231a49906384aL144-R153): Updated the `delegateAllowance` function to use `msg.sender` instead of requiring the `safe` address as a parameter. This change ensures that the function is tied to the caller's context, improving security and reducing the risk of misuse. The associated logic for resetting and scheduling delegate allowances was adjusted to reflect this change.