### PR TITLE
Guardrail gas comparison

### DIFF
--- a/snapshots/GuardrailTest.json
+++ b/snapshots/GuardrailTest.json
@@ -1,0 +1,6 @@
+{
+  "Guardrail MultiSend Tx": "93315",
+  "Guardrail Setup (using MultiSendCallOnly)": "104725",
+  "GuardrailWithMultisend MultiSend Tx": "93130",
+  "GuardrailWithMultisend Setup": "71284"
+}

--- a/src/Guardrail.sol
+++ b/src/Guardrail.sol
@@ -177,7 +177,7 @@ contract Guardrail is ITransactionGuard, IModuleGuard {
      * @dev This will revert if the operation is delegate call, but the {to} is not a allowed delegate. This will also
      *      remove the delegate allowance if the one time allowance is set
      */
-    function _checkOperationAndAllowance(address safe, address to, Enum.Operation operation) internal {
+    function _checkOperationAndAllowance(address safe, address to, Enum.Operation operation) internal virtual {
         if (operation == Enum.Operation.DelegateCall) {
             Allowance memory allowance = delegatedAllowance[safe][to];
             require(

--- a/src/GuardrailWithMultisend.sol
+++ b/src/GuardrailWithMultisend.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity =0.8.28;
+
+import {Guardrail, Enum} from "./Guardrail.sol";
+import {MultiSendCallOnly} from "safe-smart-account/contracts/libraries/MultiSendCallOnly.sol";
+
+contract GuardrailWithMultisend is Guardrail, MultiSendCallOnly {
+    /**
+     * @notice The constructor for the Guardrail contract
+     * @param delay The delay for the guard removal and delegate allowance
+     */
+    constructor(uint256 delay) Guardrail(delay) {}
+
+    /**
+     * @notice Function to check if the delegate is allowed if the operation is delegate call
+     * @param safe The address of the safe
+     * @param to The address of the delegate
+     * @param operation The operation to check
+     * @dev This will revert if the operation is delegate call, but the {to} is not a allowed delegate. This will also
+     *      remove the delegate allowance if the one time allowance is set
+     */
+    function _checkOperationAndAllowance(address safe, address to, Enum.Operation operation) internal override {
+        if (to == address(this)) {
+            // Question: Should we also check if the selector is `multiSend(...)`?
+            return;
+        }
+
+        if (operation == Enum.Operation.DelegateCall) {
+            Allowance memory allowance = delegatedAllowance[safe][to];
+            require(
+                allowance.allowedTimestamp > 0 && allowance.allowedTimestamp < block.timestamp,
+                DelegateCallNotAllowed(to)
+            );
+
+            if (allowance.oneTimeAllowance) {
+                delete delegatedAllowance[safe][to];
+            }
+        }
+    }
+}

--- a/test/GuardrailComparison.t.sol
+++ b/test/GuardrailComparison.t.sol
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity =0.8.28;
+
+import {Test, console} from "forge-std/Test.sol";
+import {Guardrail} from "../src/Guardrail.sol";
+import {GuardrailWithMultisend} from "../src/GuardrailWithMultisend.sol";
+import {Enum, Safe, SafeL2} from "safe-smart-account/contracts/SafeL2.sol";
+import {SafeProxyFactory} from "safe-smart-account/contracts/proxies/SafeProxyFactory.sol";
+import {SafeProxy} from "safe-smart-account/contracts/proxies/SafeProxy.sol";
+import {MultiSendCallOnly} from "safe-smart-account/contracts/libraries/MultiSendCallOnly.sol";
+import {ERC20Token} from "safe-smart-account/contracts/test/ERC20Token.sol";
+
+contract GuardrailTest is Test {
+    uint256 private constant DELAY = 7 days;
+
+    /**
+     * @notice The storage slot for the guard
+     * @dev This is used to check if the guard is set
+     *      Value = `keccak256("guard_manager.guard.address")`
+     */
+    bytes32 private constant GUARD_STORAGE_SLOT = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+
+    // Owner structure
+    address private owner;
+    uint256 private ownerPrivateKey;
+    address[] private owners = new address[](1);
+
+    // Safe threshold
+    uint256 private threshold = 1;
+
+    // Contract instances
+    Guardrail private guardrail;
+    GuardrailWithMultisend private guardrailWithMultisend;
+    MultiSendCallOnly private multiSendCallOnly;
+    ERC20Token private erc20Token;
+    address private singleton;
+    SafeL2 private safe;
+    SafeProxyFactory private safeProxyFactory;
+    uint256 private salt;
+
+    // Empty bytes and address
+    bytes private emptyBytes = "";
+    address private zeroAddress = address(0);
+    address payable private payableZeroAddress = payable(zeroAddress);
+
+    // Dummy data
+    address private randomAddress1;
+    address private randomAddress2;
+    address private randomAddress3;
+
+    // Helper function to get the executor signature
+    function getExecutorSignature(address ownerAddress) private pure returns (bytes memory) {
+        return abi.encodePacked(abi.encode(ownerAddress), bytes32(0), uint8(1));
+    }
+
+    // Function to get the setup data for the Safe contract
+    function getSetupData() private view returns (bytes memory) {
+        return abi.encodeWithSelector(
+            Safe.setup.selector,
+            owners,
+            threshold,
+            zeroAddress,
+            emptyBytes,
+            zeroAddress,
+            zeroAddress,
+            0,
+            payableZeroAddress
+        );
+    }
+
+    // Function to set up the owners
+    function setupOwners() private {
+        (owner, ownerPrivateKey) = makeAddrAndKey("owner");
+        owners = [owner];
+    }
+
+    // Function to set up the guardrail contract
+    function setupGuardrail() private {
+        guardrail = new Guardrail(DELAY);
+    }
+
+    // Function to set up GuardrailWithMultisend contract
+    function setupGuardrailWithMultisend() private {
+        guardrailWithMultisend = new GuardrailWithMultisend(DELAY);
+    }
+
+    // Function to set up the MultiSendCallOnly contract
+    function setupMultiSendCallOnly() private {
+        multiSendCallOnly = new MultiSendCallOnly();
+    }
+
+    // Function to set up the ERC20 token contract
+    function setupERC20Token() private {
+        vm.prank(owner);
+        erc20Token = new ERC20Token();
+    }
+
+    // Function to set up the Safe contract
+    function setupSafe() private {
+        singleton = address(new SafeL2());
+        safeProxyFactory = new SafeProxyFactory();
+        bytes memory setupData = getSetupData();
+
+        salt++;
+        safe = SafeL2(payable(safeProxyFactory.createProxyWithNonce(singleton, setupData, salt)));
+    }
+
+    // Function to set up dummy data for testing
+    function setupMultiSendTxData() private returns (bytes memory multiSendTxs) {
+        // Random generated addresses for the test
+        randomAddress1 = makeAddr("randomAddress1");
+        randomAddress2 = makeAddr("randomAddress2");
+        randomAddress3 = makeAddr("randomAddress3");
+
+        // Set some value to safe address
+        vm.deal(address(safe), 10 ether);
+        vm.prank(owner);
+        erc20Token.transfer(address(safe), 1e10);
+
+        bytes[] memory txs = new bytes[](3);
+
+        // Transfer 1 ETH to randomAddress1
+        txs[0] = abi.encodePacked(
+            uint8(0), // Operation: Call
+            randomAddress1, // Address to send to
+            uint256(1 ether), // Value to send
+            emptyBytes.length,
+            emptyBytes // Data
+        );
+
+        // Transfer 1e10 ERC20 Token to randomAddress2
+        bytes memory erc20TxData = abi.encodeWithSelector(erc20Token.transfer.selector, randomAddress2, 1e10);
+        txs[1] = abi.encodePacked(
+            uint8(0), // Operation: Call
+            randomAddress2, // Address to send to
+            uint256(0), // Value to send
+            erc20TxData.length,
+            erc20TxData // Data
+        );
+
+        // Add randomAddress3 as an owner to the Safe contract
+        bytes memory addOwnerData =
+            abi.encodeWithSelector(safe.addOwnerWithThreshold.selector, randomAddress3, threshold);
+        txs[2] = abi.encodePacked(
+            uint8(0), // Operation: Call
+            address(safe), // Address to send to
+            uint256(0), // Value to send
+            addOwnerData.length,
+            addOwnerData // Data
+        );
+
+        // Encode the transactions
+        bytes memory transactions;
+        for (uint256 i = 0; i < txs.length; i++) {
+            transactions = abi.encodePacked(transactions, txs[i]);
+        }
+
+        multiSendTxs = abi.encodeWithSelector(multiSendCallOnly.multiSend.selector, transactions);
+    }
+
+    // Function to set up the test environment
+    function setUp() public {
+        setupOwners();
+        setupGuardrail();
+        setupGuardrailWithMultisend();
+        setupERC20Token();
+        setupMultiSendCallOnly();
+        setupSafe();
+    }
+
+    // Function to test the gas usage of the Guardrail contract for MultiSendCallOnly transactions
+    function testGuardrailGasUsage() public {
+        // Using MultiSendCallOnly to immediately set the delegate (MultiSendCallOnly) and set the guard
+        bytes[] memory txs = new bytes[](2);
+
+        bytes memory setupDelegateData =
+            abi.encodeWithSelector(guardrail.immediateDelegateAllowance.selector, address(multiSendCallOnly), false);
+        txs[0] = abi.encodePacked(
+            uint8(0), // Operation: Call
+            address(guardrail), // Address to send to
+            uint256(0), // Value to send
+            setupDelegateData.length,
+            setupDelegateData // Data
+        );
+
+        bytes memory setupGuardData = abi.encodeWithSelector(safe.setGuard.selector, address(guardrail));
+        txs[1] = abi.encodePacked(
+            uint8(0), // Operation: Call
+            address(safe), // Address to send to
+            uint256(0), // Value to send
+            setupGuardData.length,
+            setupGuardData // Data
+        );
+
+        bytes memory setupDelegateAndGuardData = abi.encodePacked(txs[0], txs[1]);
+
+        bytes memory setupDelegateAndGuardMultisend =
+            abi.encodeWithSelector(multiSendCallOnly.multiSend.selector, setupDelegateAndGuardData);
+
+        vm.prank(owner);
+        safe.execTransaction(
+            address(multiSendCallOnly),
+            0,
+            setupDelegateAndGuardMultisend,
+            Enum.Operation.DelegateCall,
+            0,
+            0,
+            0,
+            zeroAddress,
+            payableZeroAddress,
+            getExecutorSignature(owner)
+        );
+        vm.snapshotGasLastCall("Guardrail Setup (using MultiSendCallOnly)");
+
+        // Moving to the next block and timestamp
+        vm.roll(vm.getBlockNumber() + 1);
+        vm.warp(vm.getBlockTimestamp() + 1);
+
+        // Setting up MultiSendCallOnly transactions
+        bytes memory multiSendTxs = setupMultiSendTxData();
+
+        // Executing the transaction.
+        vm.prank(owner);
+        safe.execTransaction(
+            address(multiSendCallOnly),
+            0,
+            multiSendTxs,
+            Enum.Operation.DelegateCall,
+            0,
+            0,
+            0,
+            zeroAddress,
+            payableZeroAddress,
+            getExecutorSignature(owner)
+        );
+        vm.snapshotGasLastCall("Guardrail MultiSend Tx");
+    }
+
+    // Function to test the gas usage of the GuardrailWithMultisend contract for MultiSendCallOnly transactions
+    function testGuardrailWithMultisendGasUsage() public {
+        // Setup the guardrailWithMultisend contract
+        bytes memory setupGuardData = abi.encodeWithSelector(safe.setGuard.selector, address(guardrailWithMultisend));
+
+        vm.prank(owner);
+        safe.execTransaction(
+            address(safe),
+            0,
+            setupGuardData,
+            Enum.Operation.Call,
+            0,
+            0,
+            0,
+            zeroAddress,
+            payableZeroAddress,
+            getExecutorSignature(owner)
+        );
+        vm.snapshotGasLastCall("GuardrailWithMultisend Setup");
+
+        // Moving to the next block and timestamp
+        vm.roll(vm.getBlockNumber() + 1);
+        vm.warp(vm.getBlockTimestamp() + 1);
+
+        // Setting up MultiSendCallOnly transactions
+        bytes memory multiSendTxs = setupMultiSendTxData();
+
+        // Executing the transaction.
+        vm.prank(owner);
+        safe.execTransaction(
+            address(guardrailWithMultisend),
+            0,
+            multiSendTxs,
+            Enum.Operation.DelegateCall,
+            0,
+            0,
+            0,
+            zeroAddress,
+            payableZeroAddress,
+            getExecutorSignature(owner)
+        );
+        vm.snapshotGasLastCall("GuardrailWithMultisend MultiSend Tx");
+    }
+}


### PR DESCRIPTION
# TLDR
- Created a `GuardrailWithMultisend` contract (which inherits `MultiSendCallOnly`) for checking gas usage
- Used forge `snapshotGasLastCall` to calculate the gas usage

## Gas Comparison

```
{
  "Guardrail MultiSend Tx": "93315",
  "Guardrail Setup (using MultiSendCallOnly)": "104725",
  "GuardrailWithMultisend MultiSend Tx": "93130",
  "GuardrailWithMultisend Setup": "71284"
}
```

- The setup cost is higher for `Guardrail` (done using MultiSendCallOnly to setup immediate delegation to `MultiSendCallOnly` and guard setup.
- The multisend transaction cost is somewhat close.

### `isolate` mode of foundry
There is not much description of the isolate (I didn't find much), but using that results in these values:
```
{
  "Guardrail MultiSend Tx": "142771",
  "Guardrail Setup (using MultiSendCallOnly)": "130997",
  "GuardrailWithMultisend MultiSend Tx": "138086",
  "GuardrailWithMultisend Setup": "95376"
}
```

- In this case, the multisend transaction cost has a significant difference.

# LLM Description
This pull request introduces a new `GuardrailWithMultisend` contract, enhances functionality in the `Guardrail` contract, and adds comprehensive tests to compare gas usage between the two implementations. The most important changes include the addition of the `GuardrailWithMultisend` contract, modifications to `_checkOperationAndAllowance` for extensibility, and the creation of a detailed test suite to evaluate and compare gas efficiency.

### New Contract Implementation:
* Added the `GuardrailWithMultisend` contract, which extends `Guardrail` and integrates the `MultiSendCallOnly` library. This contract overrides `_checkOperationAndAllowance` to handle specific cases where the delegate is the contract itself.

### Enhancements to Existing Functionality:
* Updated the `_checkOperationAndAllowance` function in the `Guardrail` contract to be `virtual`, enabling it to be overridden in derived contracts for extended functionality.

### Testing and Benchmarking:
* Created a new test suite in `GuardrailComparison.t.sol` to benchmark gas usage for both `Guardrail` and `GuardrailWithMultisend` during setup and transaction execution. This includes helper functions for setting up contracts, generating test data, and capturing gas snapshots.
* Added a JSON snapshot file (`GuardrailTest.json`) to store gas usage metrics for different operations, facilitating easy comparison.